### PR TITLE
Document ROS 2 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(
     libreach
-    VERSION 0.1.1
+    VERSION 0.1.2
     LANGUAGES CXX
     DESCRIPTION "C++ library used to communicate with Reach Robotics devices"
 )

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ has been installed prior to installing this project.
 
 ## Installation
 
-> For ROS 2 installations, please refer to the installation instructions
+> :warning: For ROS 2 installations, please refer to the installation instructions
 > provided on the [ros2](https://github.com/Robotic-Decision-Making-Lab/libreach/tree/ros2)
 > branch.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 libreach is a C++ library designed to interface with [Reach Robotics](https://reachrobotics.com/)
 devices. Get started with libreach by [installing](#installation) the project
 (refer to the [ros2](https://github.com/Robotic-Decision-Making-Lab/libreach/tree/ros2)
-branch for ROS 2-supported installation) or by exploring
+branch to install with ROS 2 support) or by exploring
 the implemented [examples](https://github.com/Robotic-Decision-Making-Lab/libreach/tree/main/examples).
 
 > :warning: This project is not affiliated with or maintained by Reach Robotics.

--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ has been installed prior to installing this project.
 
 ## Installation
 
-> :warning: For ROS 2 installations, please refer to the installation instructions
-> provided on the [ros2](https://github.com/Robotic-Decision-Making-Lab/libreach/tree/ros2)
-> branch.
-
 To install libreach, first build the library using CMake
 
 ```bash
@@ -31,6 +27,10 @@ Then, install the generated binary tree
 ```bash
 cmake --install build
 ```
+
+> :warning: For ROS 2 installations, please refer to the installation instructions
+> provided on the [ros2](https://github.com/Robotic-Decision-Making-Lab/libreach/tree/ros2)
+> branch.
 
 ## Getting help
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ has been installed prior to installing this project.
 
 ## Installation
 
+> For ROS 2 installations, please refer to the installation instructions
+> provided on the [ros2](https://github.com/Robotic-Decision-Making-Lab/libreach/tree/ros2)
+> branch.
+
 To install libreach, first build the library using CMake
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # libreach
 
 libreach is a C++ library designed to interface with [Reach Robotics](https://reachrobotics.com/)
-devices. Get started with libreach by installing the project or by exploring
+devices. Get started with libreach by [installing](#installation) the project
+(refer to the [ros2](https://github.com/Robotic-Decision-Making-Lab/libreach/tree/ros2)
+branch for ROS 2-supported installation) or by exploring
 the implemented [examples](https://github.com/Robotic-Decision-Making-Lab/libreach/tree/main/examples).
 
 > :warning: This project is not affiliated with or maintained by Reach Robotics.
@@ -27,10 +29,6 @@ Then, install the generated binary tree
 ```bash
 cmake --install build
 ```
-
-> :warning: For ROS 2 installations, please refer to the installation instructions
-> provided on the [ros2](https://github.com/Robotic-Decision-Making-Lab/libreach/tree/ros2)
-> branch.
 
 ## Getting help
 

--- a/include/libreach/driver.hpp
+++ b/include/libreach/driver.hpp
@@ -87,7 +87,7 @@ public:
   auto request(const std::vector<PacketId> & packet_ids, std::uint8_t device_id) const -> void;
 
   /// Request a packet from the specified device at some rate.
-  auto request_at_rate(const PacketId packet_id, std::uint8_t device_id, std::chrono::milliseconds rate) const -> void;
+  auto request_at_rate(PacketId packet_id, std::uint8_t device_id, std::chrono::milliseconds rate) const -> void;
 
   /// Request up to 10 packets from the specified device at some rate.
   auto request_at_rate(const std::vector<PacketId> & packet_ids, std::uint8_t device_id, std::chrono::milliseconds rate)
@@ -116,8 +116,8 @@ protected:
 private:
   struct Request
   {
-    Request(const Packet & packet, std::chrono::milliseconds rate)
-    : packet(packet),
+    Request(Packet packet, std::chrono::milliseconds rate)
+    : packet(std::move(packet)),
       rate(rate),
       next_request(std::chrono::steady_clock::now())
     {

--- a/include/libreach/udp_driver.hpp
+++ b/include/libreach/udp_driver.hpp
@@ -46,7 +46,7 @@ public:
   ///   - a session timeout for heartbeat monitoring.
   explicit UdpDriver(
     const std::string & addr,
-    const std::uint16_t port,
+    std::uint16_t port,
     std::size_t q_size = 100,
     std::size_t n_workers = 1,
     std::chrono::seconds session_timeout = std::chrono::seconds(3));

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -161,8 +161,8 @@ auto ReachDriver::request(const std::vector<PacketId> & packet_ids, std::uint8_t
   send_packet(PacketId::REQUEST, device_id, request_types);
 }
 
-auto ReachDriver::request_at_rate(PacketId packet_id, std::uint8_t device_id, std::chrono::milliseconds rate)
-  const -> void
+auto ReachDriver::request_at_rate(PacketId packet_id, std::uint8_t device_id, std::chrono::milliseconds rate) const
+  -> void
 {
   {
     const std::lock_guard<std::mutex> lock(request_lock_);

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -161,7 +161,7 @@ auto ReachDriver::request(const std::vector<PacketId> & packet_ids, std::uint8_t
   send_packet(PacketId::REQUEST, device_id, request_types);
 }
 
-auto ReachDriver::request_at_rate(const PacketId packet_id, std::uint8_t device_id, std::chrono::milliseconds rate)
+auto ReachDriver::request_at_rate(PacketId packet_id, std::uint8_t device_id, std::chrono::milliseconds rate)
   const -> void
 {
   {


### PR DESCRIPTION
## Changes Made

This PR addresses a few clang-tidy warnings and adds a reference to the `ros2` branch to the README